### PR TITLE
添加界面顶部 header 显示

### DIFF
--- a/frontend/style.css
+++ b/frontend/style.css
@@ -92,9 +92,13 @@ body.no-transition * {
     padding: 0;
 }
 
-/* Header - Hidden */
+/* Header - Visible at Top */
 header {
-    display: none;
+    background: var(--surface);
+    border-bottom: 1px solid var(--border-color);
+    padding: 1.5rem 2rem;
+    flex-shrink: 0;
+    text-align: center;
 }
 
 header h1 {
@@ -830,13 +834,17 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
+
     header {
-        padding: 1rem;
+        padding: 1rem 1.5rem;
     }
-    
+
     header h1 {
         font-size: 1.5rem;
+    }
+
+    .subtitle {
+        font-size: 0.85rem;
     }
     
     .chat-messages {


### PR DESCRIPTION
## Summary
添加界面顶部的 header 显示，展示“Course Materials Assistant”标题和副标题。

## Changes
- 取消隐藏现有的 header 元素
- 添加背景色、边框和内边距样式
- 更新移动端响应式设计
- 支持亮色和暗色主题

Fixes #2

Generated with [Claude Code](https://claude.ai/code)